### PR TITLE
MetaBox::the_value() - Added (BC Safe) $return parameter

### DIFF
--- a/wp-content/wpalchemy/MetaBox.php
+++ b/wp-content/wpalchemy/MetaBox.php
@@ -1649,10 +1649,10 @@ class WPAlchemy_MetaBox
 	 */
 	function the_value($n = NULL, $return = false)
 	{
-                if($return)
-                    return $this->get_the_value($n);
-                else
-		    echo $this->get_the_value($n);
+		if($return)
+			return $this->get_the_value($n);
+		else
+			echo $this->get_the_value($n);
 	}
 
 	/**


### PR DESCRIPTION
I have added a second argument to the MetaBox::the_value() method.

The signature now looks like:
function the_value($n = NULL, $return = false)

The $return parameter functions the same way it would for print_r().  If $return is true, the output is returned instead of echoed.

Case in point - I need to run the output through Wordpress' apply_filters() function.  Without this, I had to buffer the output like this:

``` php
    ob_start();
    $metabox->the_value($n);
    echo apply_filters('the_content', ob_get_clean());
```

After the change:

``` php
    echo apply_filters('the_content', $metabox->the_value($n, true);
```
