### PR TITLE
Repeating Field Groups

### DIFF
--- a/wp-content/wpalchemy/MetaBox.php
+++ b/wp-content/wpalchemy/MetaBox.php
@@ -433,6 +433,7 @@ class WPAlchemy_MetaBox
 	var $in_loop = FALSE;
 	var $in_template = FALSE;
 	var $group_tag;
+	var $loop_wrap;
 	var $current_post_id;
 
 	/**
@@ -1988,18 +1989,19 @@ class WPAlchemy_MetaBox
 	 * @since	1.1
 	 * @access	public
 	 */
-	function the_group_open($t = 'div')
+	function the_group_open($t = 'div', $loop_wrap = 'div')
 	{
-		echo $this->get_the_group_open($t);
+		echo $this->get_the_group_open($t, $loop_wrap);
 	}
 
 	/**
 	 * @since	1.1
 	 * @access	public
 	 */
-	function get_the_group_open($t = 'div')
+	function get_the_group_open($t = 'div', $loop_wrap = 'div')
 	{
 		$this->group_tag = $t;
+		$this->loop_wrap = $loop_wrap;
 
 		$loop_open = NULL;
 
@@ -2018,7 +2020,7 @@ class WPAlchemy_MetaBox
 				array_push($loop_open_classes, 'wpa_loop_limit-' . $this->_loop_data->limit);
 			}
 
-			$loop_open = '<div id="wpa_loop-'. $this->name .'" class="' . implode(' ', $loop_open_classes) . '">';
+			$loop_open = '<' .$loop_wrap. ' id="wpa_loop-'. $this->name .'" class="' . implode(' ', $loop_open_classes) . '">';
 		}
 
 		if ($this->is_last())
@@ -2053,7 +2055,7 @@ class WPAlchemy_MetaBox
 		
 		if ($this->is_last())
 		{
-			$loop_close = '</div>';
+			$loop_close = '</'.$this->loop_wrap.'>';
 		}
 		
 		return '</' . $this->group_tag . '>' . $loop_close;


### PR DESCRIPTION
Repeating field groups are currently wrapped with a div. This is fine, but not if you use table
rows for repeating, so I added a second parameter to the method which lets you overwrite the default div tag. In the loop it would be used as follows

``` php
$mb->the_group_open("tr", "tbody"); 
```

First argument is the element that is looped and the second is the wrapper of this repeating element
