### PR TITLE
Add _save method to `attachment` post type actions

### DIFF
--- a/wp-content/wpalchemy/MetaBox.php
+++ b/wp-content/wpalchemy/MetaBox.php
@@ -572,6 +572,10 @@ class WPAlchemy_MetaBox
 			}
 
 			add_action('save_post', array($this,'_save'));
+			
+			// Save meta for "attachment" post type
+			add_action('edit_attachment', array($this,'_save'));
+			add_action('add_attachment', array($this,'_save'));
 
 			$filters = array('save', 'head', 'foot');
 


### PR DESCRIPTION
I've added a metabox to media attachments for a project I'm working on. At first the metabox fields weren't saving values. I discovered that the built-in "attachment" post type doesn't use the `save_post` action and instead uses `edit_attachment` and `add_attachment`. This patch fixes the saving issue and allows custom meta boxes to be attached to the `attachment` post type.
