### PR TITLE
Move _global_head JS & css to own files; enqueue with wp_enqueue_script

### DIFF
--- a/wp-content/wpalchemy/MetaBox.php
+++ b/wp-content/wpalchemy/MetaBox.php
@@ -45,6 +45,8 @@ define('WPALCHEMY_VIEW_START_CLOSED', 'closed');
 
 define('WPALCHEMY_VIEW_ALWAYS_OPENED', 'always_opened');
 
+define('WPALCHEMY_PATH', plugin_dir_url(__FILE__));
+
 class WPAlchemy_MetaBox
 {
     /**
@@ -1302,152 +1304,10 @@ class WPAlchemy_MetaBox
 
         // todo: you're assuming people will want to use this exact functionality
         // consider giving a developer access to change this via hooks/callbacks
-
+		
+		wp_enqueue_style( 'wpalchemy-metabox-css', WPALCHEMY_PATH . 'metabox.css' );
         // include javascript for special functionality
-        ?><style type="text/css"> .wpa_group.tocopy { display:none; } </style>
-        <script type="text/javascript">
-        /* <![CDATA[ */
-        jQuery(function($)
-        {
-            $(document).click(function(e)
-            {
-                var elem = $(e.target);
-
-                if (elem.attr('class') && elem.filter('[class*=dodelete]').length)
-                {
-                    e.preventDefault();
-
-                    var p = elem.parents('.postbox'); /*wp*/
-
-                    var the_name = elem.attr('class').match(/dodelete-([a-zA-Z0-9_-]*)/i);
-
-                    the_name = (the_name && the_name[1]) ? the_name[1] : null ;
-
-                    /* todo: expose and allow editing of this message */
-                    if (confirm('This action can not be undone, are you sure?'))
-                    {
-                        if (the_name)
-                        {
-                            $('.wpa_group-'+ the_name, p).not('.tocopy').remove();
-                        }
-                        else
-                        {
-                            elem.parents('.wpa_group').remove();
-                        }
-
-                        var the_group = elem.parents('.wpa_group');
-
-                        if(the_group && the_group.attr('class'))
-                        {
-                            the_name = the_group.attr('class').match(/wpa_group-([a-zA-Z0-9_-]*)/i);
-
-                            the_name = (the_name && the_name[1]) ? the_name[1] : null ;
-
-                            checkLoopLimit(the_name);
-                        }
-
-                        $.wpalchemy.trigger('wpa_delete');
-                    }
-                }
-            });
-
-            $('[class*=docopy-]').click(function(e)
-            {
-                e.preventDefault();
-
-                var p = $(this).parents('.postbox'); /*wp*/
-
-                var the_name = $(this).attr('class').match(/docopy-([a-zA-Z0-9_-]*)/i)[1];
-
-                var the_group = $('.wpa_group-'+ the_name +'.tocopy', p).first();
-
-                var the_clone = the_group.clone().removeClass('tocopy last');
-
-                var the_props = ['name', 'id', 'for', 'class'];
-
-                the_group.find('*').each(function(i, elem)
-                {
-                    for (var j = 0; j < the_props.length; j++)
-                    {
-                        var the_prop = $(elem).attr(the_props[j]);
-
-                        if (the_prop)
-                        {
-                            var the_match = the_prop.match(/\[(\d+)\]/i);
-
-                            if (the_match)
-                            {
-                                the_prop = the_prop.replace(the_match[0],'['+ (+the_match[1]+1) +']');
-
-                                $(elem).attr(the_props[j], the_prop);
-                            }
-
-                            the_match = null;
-
-                            // todo: this may prove to be too broad of a search
-                            the_match = the_prop.match(/n(\d+)/i);
-
-                            if (the_match)
-                            {
-                                the_prop = the_prop.replace(the_match[0], 'n' + (+the_match[1]+1));
-
-                                $(elem).attr(the_props[j], the_prop);
-                            }
-                        }
-                    }
-                });
-
-                if ($(this).hasClass('ontop'))
-                {
-                    $('.wpa_group-'+ the_name, p).first().before(the_clone);
-                }
-                else
-                {
-                    the_group.before(the_clone);
-                }
-
-                checkLoopLimit(the_name);
-
-                $.wpalchemy.trigger('wpa_copy', [the_clone]);
-            });
-
-            function checkLoopLimit(name)
-            {
-                var elem = $('.docopy-' + name);
-
-                var the_class = $('.wpa_loop-' + name).attr('class');
-
-                if (the_class)
-                {
-                    var the_match = the_class.match(/wpa_loop_limit-([0-9]*)/i);
-
-                    if (the_match)
-                    {
-                        var the_limit = the_match[1];
-
-                        if ($('.wpa_group-' + name).not('.wpa_group.tocopy').length >= the_limit)
-                        {
-                            elem.hide();
-                        }
-                        else
-                        {
-                            elem.show();
-                        }
-                    }
-                }
-            }
-
-            /* do an initial limit check, show or hide buttons */
-            $('[class*=docopy-]').each(function()
-            {
-                var the_name = $(this).attr('class').match(/docopy-([a-zA-Z0-9_-]*)/i)[1];
-
-                checkLoopLimit(the_name);
-            });
-        });
-        /* ]]> */
-        </script>
-        <?php
+		wp_enqueue_script( 'wpalchemy-metabox-copy', WPALCHEMY_PATH . 'metabox-copy.js' );
     }
 
     /**

--- a/wp-content/wpalchemy/MetaBox.php
+++ b/wp-content/wpalchemy/MetaBox.php
@@ -1305,9 +1305,9 @@ class WPAlchemy_MetaBox
         // todo: you're assuming people will want to use this exact functionality
         // consider giving a developer access to change this via hooks/callbacks
 		
-		wp_enqueue_style( 'wpalchemy-metabox-css', WPALCHEMY_PATH . 'metabox.css' );
+        wp_enqueue_style( 'wpalchemy-metabox-css', WPALCHEMY_PATH . 'metabox.css' );
         // include javascript for special functionality
-		wp_enqueue_script( 'wpalchemy-metabox-copy', WPALCHEMY_PATH . 'metabox-copy.js' );
+        wp_enqueue_script( 'wpalchemy-metabox-copy', WPALCHEMY_PATH . 'metabox-copy.js' );
     }
 
     /**

--- a/wp-content/wpalchemy/metabox-copy.js
+++ b/wp-content/wpalchemy/metabox-copy.js
@@ -1,0 +1,138 @@
+jQuery(function($)
+{
+	$(document).click(function(e)
+	{
+		var elem = $(e.target);
+
+		if (elem.attr('class') && elem.filter('[class*=dodelete]').length)
+		{
+			e.preventDefault();
+
+			var p = elem.parents('.postbox'); /*wp*/
+
+			var the_name = elem.attr('class').match(/dodelete-([a-zA-Z0-9_-]*)/i);
+
+			the_name = (the_name && the_name[1]) ? the_name[1] : null ;
+
+			/* todo: expose and allow editing of this message */
+			if (confirm('This action can not be undone, are you sure?'))
+			{
+				if (the_name)
+				{
+					$('.wpa_group-'+ the_name, p).not('.tocopy').remove();
+				}
+				else
+				{
+					elem.parents('.wpa_group').remove();
+				}
+
+				var the_group = elem.parents('.wpa_group');
+
+				if(the_group && the_group.attr('class'))
+				{
+					the_name = the_group.attr('class').match(/wpa_group-([a-zA-Z0-9_-]*)/i);
+
+					the_name = (the_name && the_name[1]) ? the_name[1] : null ;
+
+					checkLoopLimit(the_name);
+				}
+
+				$.wpalchemy.trigger('wpa_delete');
+			}
+		}
+	});
+
+	$('[class*=docopy-]').click(function(e)
+	{
+		e.preventDefault();
+
+		var p = $(this).parents('.postbox'); /*wp*/
+
+		var the_name = $(this).attr('class').match(/docopy-([a-zA-Z0-9_-]*)/i)[1];
+
+		var the_group = $('.wpa_group-'+ the_name +'.tocopy', p).first();
+
+		var the_clone = the_group.clone().removeClass('tocopy last');
+
+		var the_props = ['name', 'id', 'for', 'class'];
+
+		the_group.find('*').each(function(i, elem)
+		{
+			for (var j = 0; j < the_props.length; j++)
+			{
+				var the_prop = $(elem).attr(the_props[j]);
+
+				if (the_prop)
+				{
+					var the_match = the_prop.match(/\[(\d+)\]/i);
+
+					if (the_match)
+					{
+						the_prop = the_prop.replace(the_match[0],'['+ (+the_match[1]+1) +']');
+
+						$(elem).attr(the_props[j], the_prop);
+					}
+
+					the_match = null;
+
+					// todo: this may prove to be too broad of a search
+					the_match = the_prop.match(/n(\d+)/i);
+
+					if (the_match)
+					{
+						the_prop = the_prop.replace(the_match[0], 'n' + (+the_match[1]+1));
+
+						$(elem).attr(the_props[j], the_prop);
+					}
+				}
+			}
+		});
+
+		if ($(this).hasClass('ontop'))
+		{
+			$('.wpa_group-'+ the_name, p).first().before(the_clone);
+		}
+		else
+		{
+			the_group.before(the_clone);
+		}
+
+		checkLoopLimit(the_name);
+
+		$.wpalchemy.trigger('wpa_copy', [the_clone]);
+	});
+
+	function checkLoopLimit(name)
+	{
+		var elem = $('.docopy-' + name);
+
+		var the_class = $('.wpa_loop-' + name).attr('class');
+
+		if (the_class)
+		{
+			var the_match = the_class.match(/wpa_loop_limit-([0-9]*)/i);
+
+			if (the_match)
+			{
+				var the_limit = the_match[1];
+
+				if ($('.wpa_group-' + name).not('.wpa_group.tocopy').length >= the_limit)
+				{
+					elem.hide();
+				}
+				else
+				{
+					elem.show();
+				}
+			}
+		}
+	}
+
+	/* do an initial limit check, show or hide buttons */
+	$('[class*=docopy-]').each(function()
+	{
+		var the_name = $(this).attr('class').match(/docopy-([a-zA-Z0-9_-]*)/i)[1];
+
+		checkLoopLimit(the_name);
+	});
+});

--- a/wp-content/wpalchemy/metabox.css
+++ b/wp-content/wpalchemy/metabox.css
@@ -1,0 +1,1 @@
+.wpa_group.tocopy { display:none; }


### PR DESCRIPTION
Why not use WordPress standard enqueue for assets like css & js?  This way you can be assured they will only get enqueued once, they are easier to debug because you can use things like breakpoints in web inspectors,  and plugins and wp_dequeue_script just the same if they need it removed.