### PR TITLE
Fix the warning in PHP 7.2

### DIFF
--- a/wp-content/wpalchemy/MetaBox.php
+++ b/wp-content/wpalchemy/MetaBox.php
@@ -2045,7 +2045,7 @@ class WPAlchemy_MetaBox
 
         $this->name = $n;
 
-        $cnt = count(!empty($this->meta[$n])?$this->meta[$n]:NULL);
+        $cnt = count(!empty($this->meta[$n])?$this->meta[$n]:[]);
 
         $length = is_null($length) ? $cnt : $length ;
 


### PR DESCRIPTION
In always throw warning when using PHP 7.2. To remove the warning, I change NULL to just blank array to avoid the issue.